### PR TITLE
Change processor usage

### DIFF
--- a/sample/src/main/java/com/mercari/sample/activity/EmailInputActivity.java
+++ b/sample/src/main/java/com/mercari/sample/activity/EmailInputActivity.java
@@ -11,10 +11,10 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.mercari.sample.R;
-import com.mercari.sample.test.ExperimentsList;
-import com.mercari.sample.test.ForExperiment;
+import com.mercari.sample.test.Experiments;
 import com.mercari.siberi.ExperimentContent;
 import com.mercari.siberi.Siberi;
+import com.mercari.siberi.annotations.ForExperiment;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -22,7 +22,7 @@ import org.json.JSONObject;
 
 public class EmailInputActivity extends AppCompatActivity {
 
-    @ForExperiment(ExperimentsList.TEST_002_CHANGE_TEXT)
+    @ForExperiment(Experiments.TEST_002_CHANGE_TEXT)
     TextView textView;
 
     public static Intent createIntent(Context context){
@@ -36,7 +36,7 @@ public class EmailInputActivity extends AppCompatActivity {
         setContentView(R.layout.activity_email_input);
         final Button button = (Button) findViewById(R.id.submit_button);
         textView = (TextView) findViewById(R.id.intro_message);
-        Siberi.runTest(ExperimentsList.TEST_001_CHANGE_BUTTON_COLOR.getTestName(), new Siberi.ExperimentRunner() {
+        Siberi.runTest(Experiments.TEST_001_CHANGE_BUTTON_COLOR, new Siberi.ExperimentRunner() {
             @Override
             public void run(ExperimentContent content) {
                 switch (content.getVariant()) {
@@ -60,7 +60,7 @@ public class EmailInputActivity extends AppCompatActivity {
             }
         });
 
-        Siberi.runTest(ExperimentsList.TEST_002_CHANGE_TEXT.getTestName(), new Siberi.ExperimentRunner() {
+        Siberi.runTest(Experiments.TEST_002_CHANGE_TEXT, new Siberi.ExperimentRunner() {
             @Override
             public void run(ExperimentContent content) {
                 switch (content.getVariant()) {
@@ -90,7 +90,7 @@ public class EmailInputActivity extends AppCompatActivity {
         });
     }
 
-    @ForExperiment(ExperimentsList.TEST_002_CHANGE_TEXT)
+    @ForExperiment(Experiments.TEST_002_CHANGE_TEXT)
     private void changeText(String text){
         Toast.makeText(this,"Experiment started",Toast.LENGTH_LONG).show();
         if(text != null) {

--- a/sample/src/main/java/com/mercari/sample/activity/SplashActivity.java
+++ b/sample/src/main/java/com/mercari/sample/activity/SplashActivity.java
@@ -6,7 +6,7 @@ import android.support.v7.app.AppCompatActivity;
 
 import com.mercari.sample.R;
 import com.mercari.sample.api.FakeApi;
-import com.mercari.sample.test.ExperimentsList;
+import com.mercari.sample.test.ExperimentsUtil;
 import com.mercari.siberi.Siberi;
 
 import org.json.JSONArray;
@@ -31,7 +31,7 @@ public class SplashActivity extends AppCompatActivity {
             }
         });
 
-        loadingTask.execute(ExperimentsList.getTestNameParams());
+        loadingTask.execute(ExperimentsUtil.getTestNameParams());
     }
 
     public void gotoNextActivity(){

--- a/siberi-library/src/main/java/com/mercari/siberi/annotations/ForExperiment.java
+++ b/siberi-library/src/main/java/com/mercari/siberi/annotations/ForExperiment.java
@@ -1,0 +1,15 @@
+package com.mercari.siberi.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({
+        java.lang.annotation.ElementType.FIELD,
+        java.lang.annotation.ElementType.TYPE,
+        java.lang.annotation.ElementType.LOCAL_VARIABLE,
+        java.lang.annotation.ElementType.METHOD
+})
+public @interface ForExperiment {
+    String value();
+}

--- a/siberi-processor/src/main/java/com/mercari/processor/ExperimentListModel.java
+++ b/siberi-processor/src/main/java/com/mercari/processor/ExperimentListModel.java
@@ -26,12 +26,9 @@ public class ExperimentListModel {
     }
 
     public ExperimentListModel(TypeElement element, Elements elementUtils){
-        if(!element.getKind().isInterface()){
-            throw new IllegalDeclarationException("Experiment is declared as class. You should declare with interface");
-        }
         String packageName = getPackageName(elementUtils, element);
         String originalClassName = getClassName(element, packageName);
-        this.className = ClassName.get(packageName,originalClassName + "List");
+        this.className = ClassName.get(packageName,originalClassName + "Util");
         setExperimentsName(element);
     }
 


### PR DESCRIPTION
Changed an architecture of experiment list from enum to String. With this change: 
- `@ForExperiment` annotation does not have to be generated so , it'si now moved to Siberi library.
- Argument of `@ForExperiment` is changed to String.
- `@ForExperimentalList` annotation only generates `getParams()` method which is used to create parameters required for a request to the server. 
