### PR TITLE
Add callback for async operation

### DIFF
--- a/siberi-library/src/main/java/com/mercari/siberi/Siberi.java
+++ b/siberi-library/src/main/java/com/mercari/siberi/Siberi.java
@@ -49,10 +49,10 @@ public class Siberi {
                     int variant = object.optInt("variant");
                     JSONObject metaData = object.optJSONObject("metadata");
                     sStorage.insert(test, variant, metaData);
+                }
 
-                    if (callback != null) {
-                        callback.hasSetExperimentContents();
-                    }
+                if (callback != null) {
+                    callback.hasSetExperimentContents();
                 }
             }
         });

--- a/siberi-library/src/main/java/com/mercari/siberi/Siberi.java
+++ b/siberi-library/src/main/java/com/mercari/siberi/Siberi.java
@@ -27,7 +27,7 @@ public class Siberi {
         }
     }
 
-    private static void setCallback(Callback callback) {
+    public static void setCallback(Callback callback) {
         Siberi.callback = callback;
     }
 

--- a/siberi-library/src/main/java/com/mercari/siberi/Siberi.java
+++ b/siberi-library/src/main/java/com/mercari/siberi/Siberi.java
@@ -17,12 +17,18 @@ public class Siberi {
     private static SiberiStorage sStorage;
     private static ExecutorService sExecutor = Executors.newSingleThreadExecutor();
 
+    private static Callback callback;
+
     private Siberi(){}
 
     public static void setUp(Context context) {
         if (sStorage == null) {
             sStorage = new SiberiSQLStorage(context);
         }
+    }
+
+    private static void setCallback(Callback callback) {
+        Siberi.callback = callback;
     }
 
     public static void setUpCustomStorage(SiberiStorage customStorage) {
@@ -43,6 +49,10 @@ public class Siberi {
                     int variant = object.optInt("variant");
                     JSONObject metaData = object.optJSONObject("metadata");
                     sStorage.insert(test, variant, metaData);
+
+                    if (callback != null) {
+                        callback.hasSetExperimentContents();
+                    }
                 }
             }
         });
@@ -87,4 +97,7 @@ public class Siberi {
         void run(ExperimentContent content);
     }
 
+    public interface Callback {
+        void hasSetExperimentContents();
+    }
 }


### PR DESCRIPTION
Sometimes it is too early to call `Siberi.runTest` before storing all experiments data in `Siberi.setExperimentContents`. This one is a proposal to address the issue.