### PR TITLE
Cursor should be closed even if the result is empty

### DIFF
--- a/siberi-library/src/main/java/com/mercari/siberi/db/SiberiSQLStorage.java
+++ b/siberi-library/src/main/java/com/mercari/siberi/db/SiberiSQLStorage.java
@@ -63,7 +63,10 @@ public class SiberiSQLStorage extends SQLiteOpenHelper implements SiberiStorage 
         String query = "SELECT * FROM " + TABLE_NAME +
                 " WHERE " + COLUMN_NAME + " = ? limit 1";
         Cursor cursor = mDb.rawQuery(query, new String[]{testName});
-        if (cursor.getCount() == 0) return null;
+        if (cursor.getCount() == 0) {
+            cursor.close();
+            return null;
+        }
         ExperimentContent content = convertFromCursor(cursor);
         cursor.close();
         return content;


### PR DESCRIPTION
Unclosed cursor will cause exceptions in Android strict mode.